### PR TITLE
Add getters for registry addresses

### DIFF
--- a/contracts/ProxyReader.sol
+++ b/contracts/ProxyReader.sol
@@ -35,8 +35,11 @@ contract ProxyReader is ERC165Upgradeable, IRegistryReader, IRecordReader, IData
             super.supportsInterface(interfaceId);
     }
 
-    function getAllRegistries() public view returns (address[] memory addrs) {
-        return [address(_unsRegistry), address(_cnsRegistry)];
+    function getAllRegistries() public view returns (address[] memory addresses) {
+        addresses = new address[](2);
+        addresses[0] = address(_unsRegistry);
+        addresses[1] = address(_cnsRegistry);
+        return addresses;
     }
 
     function tokenURI(uint256 tokenId) external view override returns (string memory) {

--- a/contracts/ProxyReader.sol
+++ b/contracts/ProxyReader.sol
@@ -35,6 +35,10 @@ contract ProxyReader is ERC165Upgradeable, IRegistryReader, IRecordReader, IData
             super.supportsInterface(interfaceId);
     }
 
+    function getAllRegistries() public view returns (address[] memory addrs) {
+        return [address(_unsRegistry), address(_cnsRegistry)];
+    }
+
     function tokenURI(uint256 tokenId) external view override returns (string memory) {
         if (_unsRegistry.exists(tokenId)) {
             return _unsRegistry.tokenURI(tokenId);


### PR DESCRIPTION
I need to get the list of all registry addresses from the proxy-reader contract. Resolution-swift library has a method "tokensOwnedBy(address)" which calls for events on CNS and uns registry contracts. 

In order to allow users to use any network and not ask for every registry address on initialization, I could just call for the proxy reader to return me back the registry addresses and then proceed with calling them directly.

Pivotal: https://www.pivotaltracker.com/story/show/178712055
Resolution-swift#tokensOwnedBy: https://github.com/unstoppabledomains/resolution-swift/blob/87be79e9d45d0984f9141dba24f3878d1c2237f3/Sources/UnstoppableDomainsResolution/NamingServices/UNS.swift#L165

Will this work?
Also, I have no idea how to deploy this to the testnet / mainnet.

