### PR TITLE
Add Ycash (YEC) resolution support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.2.2
 - Update BTC regex to support BECH32 (P2WSH) address format
+- Fix ZEC sapling regexp
 
 ## v0.2.1
 - Upgrade Ganache to v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.2.2
 - Update BTC regex to support BECH32 (P2WSH) address format
 - Fix ZEC sapling regexp
+- Add YEC regexp for Ycash support
 
 ## v0.2.1
 - Upgrade Ganache to v7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.2.2
+- Update BTC regex to support BECH32 (P2WSH) address format
+
 ## v0.2.1
 - Upgrade Ganache to v7.0.0
 - Upgrade Sandbox to v0.4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "UNS contracts and tools",
   "main": "index.js",
   "repository": "https://github.com/unstoppabledomains/uns.git",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "2.1.0",
   "keys": {
     "crypto.BTC.address": {
       "deprecatedKeyName": "BTC",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -101,6 +101,11 @@
       "deprecated": false,
       "validationRegex": "^z([a-zA-Z0-9]){94}$|^zs1([a-zA-Z0-9]){75}$|^t([a-zA-Z0-9]){34}$"
     },
+    "crypto.YEC.address": {
+      "deprecatedKeyName": "YEC",
+      "deprecated": false,
+      "validationRegex": "^y([a-zA-Z0-9]){94}$|^ys1([a-zA-Z0-9]){75}$|^s([a-zA-Z0-9]){34}$"
+    },
     "crypto.ADA.address": {
       "deprecatedKeyName": "ADA",
       "deprecated": false,

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,10 +1,10 @@
 {
-  "version": "2.0.0",
+  "version": "3.0.0",
   "keys": {
     "crypto.BTC.address": {
       "deprecatedKeyName": "BTC",
       "deprecated": false,
-      "validationRegex": "^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$"
+      "validationRegex": "^bc1[ac-hj-np-z02-9]{6,87}$|^[13][a-km-zA-HJ-NP-Z1-9]{25,39}$"
     },
     "crypto.ETH.address": {
       "deprecatedKeyName": "ETH",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -99,7 +99,7 @@
     "crypto.ZEC.address": {
       "deprecatedKeyName": "ZEC",
       "deprecated": false,
-      "validationRegex": "^z([a-zA-Z0-9]){94}$|^zs([a-zA-Z0-9]){75}$|^t([a-zA-Z0-9]){34}$"
+      "validationRegex": "^z([a-zA-Z0-9]){94}$|^zs1([a-zA-Z0-9]){75}$|^t([a-zA-Z0-9]){34}$"
     },
     "crypto.ADA.address": {
       "deprecatedKeyName": "ADA",


### PR DESCRIPTION
Add [Ycash](https://y.cash/) address resolution support.  
Ycash (YEC) was a Zcash (ZEC) fork over 2 years ago. Nearly 50% of Ycash holders today are also Zcash holders.  
The Ycash community would like to add resolution support for Ycash for Unstoppable Domains... just like Zcash is currently supported.  

We've initiated the PR here with the regexp to validate the current address formats: sprout (obsolescent), sapling, and transparent. 