### PR TITLE
[REG-433] Revert config of ProxyReader for testnets

### DIFF
--- a/uns-config.json
+++ b/uns-config.json
@@ -164,12 +164,11 @@
                     "forwarder": "0xFCc1A95B7287Ae7a8B7cA813F12991dF5714d4C7"
                 },
                 "ProxyReader": {
-                    "address": "0xE3b961856C417d081a02cBa0161a051268F52677",
+                    "address": "0x9A70ff906D422C2FD0F7B94244D6b36DB62Ee982",
                     "legacyAddresses": [
-                        "0x9A70ff906D422C2FD0F7B94244D6b36DB62Ee982",
                         "0xFc5f608149f4D9e2Ed0733efFe9DD57ee24BCF68"
                     ],
-                    "deploymentBlock": "0x65bdfe"
+                    "deploymentBlock": "0x5ede68"
                 },
                 "TwitterValidationOperator": {
                     "address": "0x0000000000000000000000000000000000000000",
@@ -439,12 +438,11 @@
                     "forwarder": "0x0000000000000000000000000000000000000000"
                 },
                 "ProxyReader": {
-                    "address": "0x6fe7c857C1B0E54492C8762f27e0a45CA7ff264B",
+                    "address": "0xbd9e01F6513E7C05f71Bf21d419a3bDF1EA9104b",
                     "legacyAddresses": [
-                        "0xbd9e01F6513E7C05f71Bf21d419a3bDF1EA9104b",
                         "0x332A8191905fA8E6eeA7350B5799F225B8ed30a9"
                     ],
-                    "deploymentBlock": "0x0189f72d"
+                    "deploymentBlock": "0x016e0c70"
                 },
                 "TwitterValidationOperator": {
                     "address": "0x0000000000000000000000000000000000000000",


### PR DESCRIPTION
Resolution library fails with new ProxyReader implementation. I had to revert the config until the resolution.js will be fixed.
It is possible to use sandbox for testing, it has upgraded version of ProxyReader 