### PR TITLE
Remove HRC20 and ERC20 versions for ELA

### DIFF
--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "information": {
     "description": "This file desribes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/domain-registry-essentials/records-reference",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -446,16 +446,6 @@
       "validationRegex": "^0x[a-fA-F0-9]{40}$",
       "deprecated": false
     },
-    "crypto.ELA.version.HRC20.address": {
-      "deprecatedKeyName": "ELA_HRC20",
-      "validationRegex": "^0x[a-fA-F0-9]{40}$",
-      "deprecated": false
-    },
-    "crypto.ELA.version.ERC20.address": {
-      "deprecatedKeyName": "ELA_ERC20",
-      "validationRegex": "^0x[a-fA-F0-9]{40}$",
-      "deprecated": false
-    },
     "crypto.USDT.version.ERC20.address": {
       "deprecatedKeyName": "USDT_ERC20",
       "validationRegex": "^0x[a-fA-F0-9]{40}$",


### PR DESCRIPTION
https://linear.app/unstoppable-domains/issue/SUP-296/changes-to-ela-address-configuration

From @jim: 

I have a thread with a Essentials wallet who just provided the below feedback about configuring ELA addresses. Can someone please help implement the change?

> 
> FYI here are a few improvements that could be made for the "ELA" currency on UD:
> 
> We don't have HRC20 and ERC20 wrapped versions, those 2 lines could be removed