### PR TITLE
[ECH-431] feat: Add FAB token into resolver keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.14
+
+- Add `FAB` token to resolver list
+
 ## v0.5.13
 
 - Add `FIRO` token to resolver list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.5.13",
+  "version": "0.5.14",
   "description": "UNS contracts and tools",
   "main": "index.js",
   "repository": "https://github.com/unstoppabledomains/uns.git",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.9",
+  "version": "2.1.10",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",
@@ -2490,6 +2490,11 @@
       "deprecatedKeyName": "MOBX",
       "validationRegex": "^fetch[a-zA-Z0-9]{39}$",
       "deprecated": false
+    },
+    "crypto.FAB.address": {
+      "deprecatedKeyName": "FAB",
+      "deprecated": false,
+      "validationRegex": "^[a-zA-Z0-9]{34}$"
     }
   }
 }


### PR DESCRIPTION
Adding FAB token into resolver keys. Since there was no regex provided, I simply took their block explorer website to see wallet examples:

- https://fabexplorer.info/#/address-info/1Q256X2XLESf3TZGy9pYDaHpqijXaY8BYH
- https://fabexplorer.info/#/address-info/1B45ya5jaCNWETcJ1ispoXgNHhYUPJKVEz