### PR TITLE
[ECH-436] feat: Add FET as a multi-chain token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.5.14
+## v0.5.15
 
 - Add `FET` as a multi-chain token to resolver list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v0.5.14
 
+- Add `FET` as a multi-chain token to resolver list
+
+## v0.5.14
+
 - Add `FAB` token to resolver list
 
 ## v0.5.13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.5.14",
+  "version": "0.5.15",
   "description": "UNS contracts and tools",
   "main": "index.js",
   "repository": "https://github.com/unstoppabledomains/uns.git",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.10",
+  "version": "2.1.11",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",
@@ -2169,6 +2169,16 @@
     "crypto.FET.address": {
       "deprecatedKeyName": "FET",
       "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": true
+    },
+    "crypto.FET.version.ERC20.address": {
+      "deprecatedKeyName": "FET_ERC20",
+      "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": false
+    },
+    "crypto.FET.version.FETCHAI.address": {
+      "deprecatedKeyName": "FET_FETCHAI",
+      "validationRegex": "^fetch[a-zA-Z0-9]{39}$",
       "deprecated": false
     },
     "crypto.OXT.address": {


### PR DESCRIPTION
Currently `FET` is a single-chain token in the resolver keys config. This PR makes it a multi-chain token in ERC20 and Fetch.ai chains.