### PR TITLE
- Validation Regex for Native HBAR addresses is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.5.18",
+  "version": "0.5.19",
   "description": "UNS contracts and tools",
   "main": "index.js",
   "repository": "https://github.com/unstoppabledomains/uns.git",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.13",
+  "version": "2.1.14",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",
@@ -1343,7 +1343,7 @@
     },
     "crypto.HBAR.address": {
       "deprecatedKeyName": "HBAR",
-      "validationRegex": "^[a-zA-Z0-9]*$",
+      "validationRegex": "^(0|(?:[1-9]\\d*))\\.(0|(?:[1-9]\\d*))\\.(0|(?:[1-9]\\d*))(?:-([a-z]{5}))?$",
       "deprecated": false
     },
     "crypto.TEL.version.ERC20.address": {


### PR DESCRIPTION
The used HBAR address validation regex was not working properly. After checking the following HBAR official reference, the validation regex is fixed. 

Linear Task: [ECh-429](https://linear.app/unstoppable-domains/issue/ECH-429/bug-adding-native-hbar-address)

Reference: https://hips.hedera.com/hip/hip-15#:~:text=kw%0A0.0.123%2Dvfmkwxxxx-,An%20address,-that%20is%20received