### PR TITLE
Update Hedera address regex

### DIFF
--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1343,7 +1343,7 @@
     },
     "crypto.HBAR.address": {
       "deprecatedKeyName": "HBAR",
-      "validationRegex": "^[a-zA-Z0-9]*$",
+      "validationRegex": "^(0|(?:[1-9]\\d*))\\.(0|(?:[1-9]\\d*))\\.(0|(?:[1-9]\\d*))(?:-([a-z]{5}))?$",
       "deprecated": false
     },
     "crypto.TEL.version.ERC20.address": {


### PR DESCRIPTION
The current regular expression for `HBAR` (Hedera) does not accept a valid address, such as `0.0.1345041`. According to [HIP-15](https://hips.hedera.com/hip/hip-15) the following regular expression defines a Hedera address:

```
/^(0|(?:[1-9]\d*))\.(0|(?:[1-9]\d*))\.(0|(?:[1-9]\d*))(?:-([a-z]{5}))?$/
```

Updating the UNS entry for Hedera to include the correct regular expression.