### PR TITLE
[ECH-520] - Fixing .klever address validation regex.

### DIFF
--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -2108,7 +2108,7 @@
     },
     "crypto.KLV.address": {
       "deprecatedKeyName": "KLV",
-      "validationRegex": "^(klv)[a-z0-9]{59}$",
+      "validationRegex": "^((k|K)(l|L)(v|V))[a-zA-Z0-9]{59}$",
       "deprecated": false
     },
     "crypto.BTCST.address": {


### PR DESCRIPTION
[ECH-520](https://linear.app/unstoppable-domains/issue/ECH-520/klever-address-validation-problem-on-mobile-website) - fix: klever address regex is not working right. Needs to be changed. 


* Changes
      - .klever regex is updated. 
      - package.json and resolver-keys.json versions are increased. 

## PR Checklist

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files. 
  ```
  // @author Unstoppable Domains, Inc.
  // @date {Month} {Day}(ordinal), {Year}
  ```
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [x] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
### 5. Sandbox
- [ ] Make sure that the Sandbox is updated if changes have been made to contracts or deployment configuration.
  ```
  yarn rebuild:sandbox
  ```
### 6. Package versioning
- [ ] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [ ] Make sure `tag` was released for the new version of the package in order to be able to add the package as a dependency.
  ```
  git tag v{version}
  git push origin --tags
  ```
- [ ] Make sure that the `CHANGELOG` is updated with short description for the new version. 
### 7. Code review
- [] `resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
