### PR TITLE
Update USDC, BNB, ONE, XVG and LSK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.6.22
+
+- Add multi-chain records for `BNB` token
+- Add multi-chain records for `USDC` token
+- Update validation regex for `ONE`
+- Update validation regex for `XVG`
+- Update validation regex for `LSK`
+
 ## v0.6.21
 
 - Add `DESO` token to resolver list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "description": "UNS contracts and tools",
   "repository": "https://github.com/unstoppabledomains/uns.git",
   "main": "./dist/index.js",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -58,8 +58,33 @@
     },
     "crypto.USDC.address": {
       "deprecatedKeyName": "USDC",
+      "deprecated": true,
+      "validationRegex": "^0x[a-fA-F0-9]{40}$"
+    },
+    "crypto.USDC.version.ERC20.address": {
+      "deprecatedKeyName": "USDC_ERC20",
       "deprecated": false,
       "validationRegex": "^0x[a-fA-F0-9]{40}$"
+    },
+    "crypto.USDC.version.OKT.address": {
+      "deprecatedKeyName": "USDC_OKT",
+      "deprecated": false,
+      "validationRegex": "^0x[a-fA-F0-9]{40}$|^ex[a-zA-HJ-NP-Z0-9]{6,90}$"
+    },
+    "crypto.USDC.version.MATIC.address": {
+      "deprecatedKeyName": "USDC_MATIC",
+      "deprecated": false,
+      "validationRegex": "^0x[a-fA-F0-9]{40}$"
+    },
+    "crypto.USDC.version.SOL.address": {
+      "deprecatedKeyName": "USDC_SOL",
+      "deprecated": false,
+      "validationRegex": "^[a-zA-Z0-9]*$"
+    },
+    "crypto.USDC.version.AVAX.address": {
+      "deprecatedKeyName": "USDC_AVAX",
+      "deprecated": false,
+      "validationRegex": "^[a-zA-Z0-9]*$"
     },
     "crypto.BAT.address": {
       "deprecatedKeyName": "BAT",
@@ -143,8 +168,18 @@
     },
     "crypto.BNB.address": {
       "deprecatedKeyName": "BNB",
-      "deprecated": false,
+      "deprecated": true,
       "validationRegex": "^bnb[0-9a-z]{39}$"
+    },
+    "crypto.BNB.version.BEP2.address": {
+      "deprecatedKeyName": "BNB_BEP2",
+      "deprecated": false,
+      "validationRegex": "^(bnb|tbnb)[a-zA-HJ-NP-Z0-9]{39}$"
+    },
+    "crypto.BNB.version.BEP20.address": {
+      "deprecatedKeyName": "BNB_BEP20",
+      "deprecated": false,
+      "validationRegex": "^0x[a-fA-F0-9]{40}$"
     },
     "crypto.BTG.address": {
       "deprecatedKeyName": "BTG",
@@ -249,7 +284,7 @@
     "crypto.LSK.address": {
       "deprecatedKeyName": "LSK",
       "deprecated": false,
-      "validationRegex": "^\\d{1,21}[L]$"
+      "validationRegex": "^\\d{1,21}[L]$|^[0-9a-z]{3}[23456789abcdefghjkmnopqrstuvwxyz]{38}$"
     },
     "crypto.ATOM.address": {
       "deprecatedKeyName": "ATOM",
@@ -329,7 +364,7 @@
     "crypto.XVG.address": {
       "deprecatedKeyName": "XVG",
       "deprecated": false,
-      "validationRegex": "^[a-zA-Z0-9]{34}$"
+      "validationRegex": "^[a-zA-Z0-9]{34}$|^[1-9A-HJ-NP-Za-km-z]{95}$"
     },
     "crypto.ALGO.address": {
       "deprecatedKeyName": "ALGO",
@@ -349,7 +384,7 @@
     "crypto.ONE.address": {
       "deprecatedKeyName": "ONE",
       "deprecated": false,
-      "validationRegex": "^one[a-zA-Z0-9]{39}$"
+      "validationRegex": "^one[a-zA-Z0-9]{39}$|^0x[a-fA-F0-9]{40}$"
     },
     "crypto.BNTY.address": {
       "deprecatedKeyName": "BNTY",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.19",
+  "version": "2.1.20",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",


### PR DESCRIPTION
## Changes

 - USDC and BNB are now multi-chain coins. Old records are marked as `deprecated`. Validation regexes for new chains were taken from "base" currency tickers.
 - Updated regex for ONE, XVG and LSK to include alternative address formats.


## PR Checklist

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files. 
  ```
  // @author Unstoppable Domains, Inc.
  // @date {Month} {Day}(ordinal), {Year}
  ```
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [x] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [ ] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [x] Make sure that the `CHANGELOG` is updated with short description for the new version. 
### 6. Code review
- [ ] `resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
