### PR TITLE
[ECH-564][ECH-625] Fix XLA token regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.28
+
+- Fix `XLA` token regex
+
 ## v0.6.27
 
 - UNSRegistry@0.6.3 Cleanup deprecated methods

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.6.28
 
+- Add `GTH` token to resolver list
 - Fix `XLA` token regex
 
 ## v0.6.27

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "description": "UNS contracts and tools",
   "repository": "https://github.com/unstoppabledomains/uns.git",
   "main": "./dist/index.js",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -2620,6 +2620,11 @@
       "deprecatedKeyName": "APT",
       "validationRegex": "^0x[a-f0-9]{64}$",
       "deprecated": false
+    },
+    "crypto.GTH.address": {
+      "deprecatedKeyName": "GTH",
+      "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": false
     }
   }
 }

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.21",
+  "version": "2.1.22",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",
@@ -2613,7 +2613,7 @@
     },
     "crypto.XLA.address": {
       "deprecatedKeyName": "XLA",
-      "validationRegex": "^0x[a-zA-Z0-9]*$",
+      "validationRegex": "^S(s)?+([1-9A-HJ-NP-Za-km-z]{96})$",
       "deprecated": false
     },
     "crypto.APT.address": {


### PR DESCRIPTION
## PR Checklist

This PR fixes `XLA` (Scala) token regex:
<img width="727" alt="regex101: build, test, and debug regex 2023-01-16 23-53-59" src="https://user-images.githubusercontent.com/325422/212771908-2a770b0d-109f-4ce6-b2f8-90917c3eb905.png">

Also it adds Gather token into the resolver keys: [ECH-625](https://linear.app/unstoppable-domains/issue/ECH-625/new-currency-support-gather-gth)

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files. 
  ```
  // @author Unstoppable Domains, Inc.
  // @date {Month} {Day}(ordinal), {Year}
  ```
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [x] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [x] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [x] Make sure that the `CHANGELOG` is updated with short description for the new version. 
### 6. Code review
- [x] `resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
