### PR TITLE
[ECH-564] Fix XLA regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.29
+
+- Fix `XLA` token regex
+
 ## v0.6.28
 
 - Add `GTH` token to resolver list

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "UNS contracts and tools",
   "repository": "https://github.com/unstoppabledomains/uns.git",
   "main": "./dist/index.js",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.22",
+  "version": "2.1.23",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",
@@ -2613,7 +2613,7 @@
     },
     "crypto.XLA.address": {
       "deprecatedKeyName": "XLA",
-      "validationRegex": "^S(s)?+([1-9A-HJ-NP-Za-km-z]{96})$",
+      "validationRegex": "^(S|Ss)+([1-9A-HJ-NP-Za-km-z]{96})$",
       "deprecated": false
     },
     "crypto.APT.address": {


### PR DESCRIPTION
## PR Checklist

A fast-follow PR to patch XLA token regex, as the previous one fails inside `new RegExp()` call.

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files. 
  ```
  // @author Unstoppable Domains, Inc.
  // @date {Month} {Day}(ordinal), {Year}
  ```
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [x] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [x] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [x] Make sure that the `CHANGELOG` is updated with short description for the new version. 
### 6. Code review
- [x] `resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
