### PR TITLE
[ECW 3026] Added okb erc20 and deprecate okc erc20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.8.45
+
+- Deprecated `OKC` ERC20 and added `OKB` ERC20
+
 ## v0.8.44
 
 - Fix missing config variables

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.30",
+  "version": "2.1.31",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",
@@ -531,10 +531,15 @@
       "validationRegex": "^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$",
       "deprecated": false
     },
+    "crypto.USDT.version.OKB.address": {
+      "deprecatedKeyName": "USDT_OKB",
+      "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": false
+    },
     "crypto.USDT.version.OKC.address": {
       "deprecatedKeyName": "USDT_OKC",
       "validationRegex": "^0x[a-fA-F0-9]{40}$|^ex[a-zA-HJ-NP-Z0-9]{6,90}$",
-      "deprecated": false
+      "deprecated": true
     },
     "crypto.FTM.version.ERC20.address": {
       "deprecatedKeyName": "FTM_ERC20",


### PR DESCRIPTION
## PR Checklist
Context: https://linear.app/unstoppable-domains/issue/ECW-3026/update-currency-okc-token

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager`, `ProxyReader`, `ENSCustody` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager`, `ProxyReader`, `ENSCustody` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files.
  ```
  // @author Unstoppable Domains, Inc.
  // @date {Month} {Day}(ordinal), {Year}
  ```
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `ens-config.json` is increased if changes have been made to the config.
- [x] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `ens-resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [ ] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [ ] Make sure that the `CHANGELOG` is updated with short description for the new version.
### 6. Code review
- [ ] `resolver-keys.json` code review is required from **DevTools** team
- [ ] `ens-resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
