### PR TITLE
Add WETH token + USDT_MATIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.9.13
+
+- Added `USDT` MATIC token to resolver list
+- Added `WETH` token to resolver list
+
 ## v0.9.12
 
 - Upgraded `UNSRegistry` and `MintingManager` on Polygon Mainnet
@@ -139,7 +144,7 @@
 
 ## v0.8.28
 
-- ENSCustody@0.1.3 - Added `owner` parameter into `data` when depositing into custody 
+- ENSCustody@0.1.3 - Added `owner` parameter into `data` when depositing into custody
 
 ## v0.8.27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "description": "UNS contracts and tools",
   "repository": "https://github.com/unstoppabledomains/uns.git",
   "main": "./dist/index.js",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.32",
+  "version": "2.1.33",
   "information": {
     "description": "This file describes all resolver keys with a defined meaning and related metadata used by Unstoppable Domains UNS Registry",
     "documentation": "https://docs.unstoppabledomains.com/developer-toolkit/records-reference/",

--- a/resolver-keys.json
+++ b/resolver-keys.json
@@ -511,8 +511,28 @@
       "validationRegex": "^0x[a-fA-F0-9]{40}$",
       "deprecated": false
     },
+    "crypto.WETH.version.ERC20.address": {
+      "deprecatedKeyName": "WETH_ERC20",
+      "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": false
+    },
+    "crypto.WETH.version.MATIC.address": {
+      "deprecatedKeyName": "WETH_MATIC",
+      "deprecated": false,
+      "validationRegex": "^0x[a-fA-F0-9]{40}$"
+    },
+    "crypto.WETH.version.BEP20.address": {
+      "deprecatedKeyName": "WETH_BEP20",
+      "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": false
+    },
     "crypto.USDT.version.ERC20.address": {
       "deprecatedKeyName": "USDT_ERC20",
+      "validationRegex": "^0x[a-fA-F0-9]{40}$",
+      "deprecated": false
+    },
+    "crypto.USDT.version.MATIC.address": {
+      "deprecatedKeyName": "USDT_MATIC",
       "validationRegex": "^0x[a-fA-F0-9]{40}$",
       "deprecated": false
     },


### PR DESCRIPTION
[TICKET](https://linear.app/unstoppable-domains/issue/ECW-3300/%5Bbug%5D-usdt-tether-not-available-on-polygon-chain)

Adds WETH token for ERC20, BEP20, and MATIC
Adds MATIC for USDT token

## PR Checklist

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager` or `ProxyReader` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files. 
  ```
  // @author Unstoppable Domains, Inc.
  // @date {Month} {Day}(ordinal), {Year}
  ```
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [x] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [x] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [x] Make sure that the `CHANGELOG` is updated with short description for the new version. 
### 6. Code review
- [ ] `resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
