### PR TITLE
[REG-1464] Upgraded ENSCustody

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -5157,6 +5157,161 @@
           }
         }
       }
+    },
+    "1bbb1b9ea42f2c5fcd245bd013a4b84d5954dd9463144d90849d3b09021b6641": {
+      "address": "0x84Ee928F923c5E662e39c750042e4b396471926C",
+      "txHash": "0xd7747f3b33b36aea52a9b4f3bab1964e622495ca34a060076bdb9d519272cf1d",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC2771RegistryContext",
+            "src": "contracts/metatx/ERC2771RegistryContext.sol:89"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)12249_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)12249_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)12249_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/.openzeppelin/sepolia.json
+++ b/.openzeppelin/sepolia.json
@@ -985,6 +985,161 @@
           }
         }
       }
+    },
+    "1bbb1b9ea42f2c5fcd245bd013a4b84d5954dd9463144d90849d3b09021b6641": {
+      "address": "0x055eBff8E490a2341c606cbcB598DdF8E58A26c1",
+      "txHash": "0xf5689ba522117f5dba377b11c4b2b4014091472b04e9533eafbf26649df0c3b4",
+      "layout": {
+        "solcVersion": "0.8.17",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC2771RegistryContext",
+            "src": "contracts/metatx/ERC2771RegistryContext.sol:89"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)12249_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)12249_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)12249_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        },
+        "namespaces": {}
+      }
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.9.38
+
+- Upgraded `ENSCustody@0.1.4` on Sepolia and Mainnet
+
 ## v0.9.37
 
 - Fixed `uns-config.json` for `RegistrarCustody`

--- a/ens-config.json
+++ b/ens-config.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.8",
+    "version": "0.2.9",
     "networks": {
         "1": {
             "contracts": {
@@ -45,7 +45,7 @@
                 "ENSCustody": {
                     "address": "0x27c9B34eB43523447d3e1bcf26f009D814522687",
                     "deploymentBlock": "0x010ae8a9",
-                    "implementation": "0x1FF7fC4473E3CDA0428830a1bc96028A0C12244C",
+                    "implementation": "0x84Ee928F923c5E662e39c750042e4b396471926C",
                     "forwarder": "0x27c9B34eB43523447d3e1bcf26f009D814522687"
                 },
                 "LegacyENSRegistry": {
@@ -219,7 +219,7 @@
                 "ENSCustody": {
                     "address": "0xd2Bf816C7b23fF6e7d141ECC4c1e41DcC857aD45",
                     "deploymentBlock": "0x5588b9",
-                    "implementation": "0x49Ac063337cF2fB26dD421Ab650b893CD54b900F",
+                    "implementation": "0x055eBff8E490a2341c606cbcB598DdF8E58A26c1",
                     "forwarder": "0xd2Bf816C7b23fF6e7d141ECC4c1e41DcC857aD45"
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uns",
-  "version": "0.9.37",
+  "version": "0.9.38",
   "description": "UNS contracts and tools",
   "repository": "https://github.com/unstoppabledomains/uns.git",
   "main": "./dist/index.js",

--- a/scripts/propose_ENSCustody.ts
+++ b/scripts/propose_ENSCustody.ts
@@ -7,7 +7,7 @@ async function main () {
   console.log('Network:', network.name);
 
   const chainId: number = unwrap(network.config, 'chainId');
-  if (![1, 5, 1337].includes(chainId)) {
+  if (![1, 1337, 11155111].includes(chainId)) {
     throw new Error(`Unsupported network ${chainId}`);
   }
 

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1047,22 +1047,23 @@ const proposeENSCustodyTask: Task = {
     }
 
     ctx.log('Preparing proposal...');
-    const proposal = await defender.proposeUpgrade(
+    const proposal = await defender.proposeUpgradeWithApproval(
       ENSCustody.address,
       await ethers.getContractFactory(ArtifactName.ENSCustody),
       {
-        title: `Propose ENSCustody to v${version}`,
-        multisig: ctx.multisig,
+        useDefenderDeploy: false,
       },
     );
 
-    if (proposal.metadata?.newImplementationAddress) {
+    const receipt = await proposal.txResponse?.wait();
+
+    if (receipt?.contractAddress) {
       await ctx.saveContractConfig(
         EnsContractName.ENSCustody,
         await ethers.getContractAt(ArtifactName.ENSCustody, ENSCustody.address),
-        proposal.metadata.newImplementationAddress,
+        receipt.contractAddress,
       );
-      await verify(ctx, proposal.metadata.newImplementationAddress, []);
+      await verify(ctx, receipt.contractAddress, []);
     }
     ctx.log('Upgrade proposal created at:', proposal.url);
   },


### PR DESCRIPTION
## PR Checklist

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager`, `ProxyReader`, `ENSCustody`, or `RegistrarCustody` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager`, `ProxyReader`, `ENSCustody`, or `RegistrarCustody` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** is defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files, including `RegistrarCustody`.
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [x] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `ens-config.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `ens-resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [x] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [ ] Make sure that the `CHANGELOG` is updated with short description for the new version.
### 6. Code review
- [ ] `resolver-keys.json` code review is required from **DevTools** team
- [ ] `ens-resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
