### PR TITLE
[SRE-1497] Github actions update to use upload and download-artifact@v4

### DIFF
--- a/.github/workflows/contracts_size.yml
+++ b/.github/workflows/contracts_size.yml
@@ -22,7 +22,7 @@ jobs:
       - run: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
       - run: yarn compile:size
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: hardhat-contract-sizer-output
           include-hidden-files: true
@@ -45,7 +45,7 @@ jobs:
           key: uns-yarn-${{ hashFiles('**/yarn.lock') }}
       - run: yarn install
         if: steps.cache.outputs.cache-hit != 'true'
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: hardhat-contract-sizer-output
           path: cache/


### PR DESCRIPTION
Github actions/workflow update
https://linear.app/unstoppable-domains/issue/SRE-1497/update-downloadupload-artifacts-to-v4

Email from Github Dec 10th, 2024:

Artifact actions v3 will be closing down by January 30, 2025. You are receiving this email because you have GitHub Actions workflows using v3 of actions/upload-artifact or actions/download-artifact. After this date using v3 of these actions will result in a workflow failure. Artifacts within their retention period will remain accessible from the UI or REST API regardless of the version used to upload.


## PR Checklist

### 1. Contracts versioning
- [ ] Make sure that the `patch` version of the contracts is increased if changes have been made to the `UNSRegistry`, `MintingManager`, `ProxyReader`, `ENSCustody`, or `RegistrarCustody` contracts.
- [ ] Make sure that the `minor` version of the contracts is increased if breaking changes have been made to the `UNSRegistry`, `MintingManager`, `ProxyReader`, `ENSCustody`, or `RegistrarCustody` contracts. It includes changes of interfaces.
### 2. Contracts licensing
- [ ] Make sure that no **SPDX-License-Identifier** is defined in contracts.
- [ ] Make sure that the **header** is added to the new contract files, including `RegistrarCustody`.
### 3. Coverage
- [ ] Make sure that the coverage of contracts has not decreased and strive **100%**
### 4. Configs versioning
- [ ] Make sure that the version of `uns-config.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `ens-config.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `resolver-keys.json` is increased if changes have been made to the config.
- [ ] Make sure that the version of `ens-resolver-keys.json` is increased if changes have been made to the config.
### 5. Package versioning
- [ ] Make sure that the `patch` version of package is increased if valuable changes have been made to the package. It includes contracts update, configs update, etc.
- [ ] Make sure that the `major.minor` version of package is synced with version of `UNSRegistry` contract.
- [ ] Make sure that the `CHANGELOG` is updated with short description for the new version.
### 6. Code review
- [ ] `resolver-keys.json` code review is required from **DevTools** team
- [ ] `ens-resolver-keys.json` code review is required from **DevTools** team
- [ ] For all other changes code review is required from **Registry** team
